### PR TITLE
fix : 이메일 인증구현 수정

### DIFF
--- a/src/main/java/com/sparta/reviewspotproject/controller/UserController.java
+++ b/src/main/java/com/sparta/reviewspotproject/controller/UserController.java
@@ -58,6 +58,7 @@ public class UserController {
         return ResponseEntity.ok("회원가입이 성공적으로 완료되었습니다.");
     }
 
+
     // 로그아웃
     @PostMapping("/logout")
     public ResponseEntity<String> logout(@AuthenticationPrincipal UserDetailsImpl userDetails) {

--- a/src/main/java/com/sparta/reviewspotproject/dto/SignupRequestDto.java
+++ b/src/main/java/com/sparta/reviewspotproject/dto/SignupRequestDto.java
@@ -32,8 +32,6 @@ public class SignupRequestDto {
     @NotBlank(message = "Email을 입력해주세요.")
     private String email;
 
-    @NotNull(message = "Email로 발송된 인증번호를 입력해주세요.")
-    private String verificationCode;
 
 }
 

--- a/src/main/java/com/sparta/reviewspotproject/repository/UserRepository.java
+++ b/src/main/java/com/sparta/reviewspotproject/repository/UserRepository.java
@@ -2,9 +2,11 @@ package com.sparta.reviewspotproject.repository;
 
 import com.sparta.reviewspotproject.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 
+@Repository
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByUserId(String username);
     Optional<User> findByEmail(String email);


### PR DESCRIPTION
회원가입 시 이메일인증을 하지 않아도 가입허가 -> 회원상태를 인증전 "NotAuth"로 변경해 DB에 저장하도록 수정하였습니다.
로그인 시 이메일 인증이 되지 않은 사용자는 이메일 인증이 필요하다는 API와 service로직이 필요합니다. 